### PR TITLE
feat: Adding manual schema overwrite for properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 *Empower APIs with Seamless Documentation Precision*
 
 [![codecov](https://codecov.io/github/vuryss/dokky/branch/master/graph/badge.svg?token=XXj2PesW0g)](https://codecov.io/github/vuryss/dokky)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/vuryss/dokky?utm_source=oss&utm_medium=github&utm_campaign=vuryss%2Fdokky&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 ## Overview
 
@@ -22,6 +23,23 @@ To be used inside frameworks for automatic generation of API Documentation (simi
 
 ## Example usage:
 
+### Overwriting single property's schema
+
+```php
+class DataWithSchemaOverwrite
+{
+    #[Property(
+        schema: new Schema(
+            description: 'Some description',
+            examples: ['test1', 'test2'],
+            enum: ['test1', 'test2', 'test3']
+        )
+    )]
+    public string $property;
+}
+```
+
+### Full documentation example
 ```php
 $componentsRegistry = new Dokky\ComponentsRegistry();
 $componentsGenerator = new Dokky\ComponentsGenerator(

--- a/src/Attribute/Property.php
+++ b/src/Attribute/Property.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dokky\Attribute;
+
+use Dokky\OpenApi\Schema;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+readonly class Property
+{
+    public function __construct(
+        public ?Schema $schema = null,
+    ) {
+    }
+}

--- a/src/ClassSchemaGenerator/ClassSchemaGenerator.php
+++ b/src/ClassSchemaGenerator/ClassSchemaGenerator.php
@@ -129,6 +129,10 @@ readonly class ClassSchemaGenerator implements ClassSchemaGeneratorInterface
             if (Undefined::VALUE === $propertySchema->default) {
                 $required[] = $finalName;
             }
+
+            if (null !== $propertyContext->schema) {
+                $propertySchema->manualOverwrite($propertyContext->schema);
+            }
         }
 
         $schema->properties = $properties;

--- a/src/ClassSchemaGenerator/PropertyContext.php
+++ b/src/ClassSchemaGenerator/PropertyContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Dokky\ClassSchemaGenerator;
 
+use Dokky\OpenApi\Schema;
+
 readonly class PropertyContext
 {
     /**
@@ -21,6 +23,7 @@ readonly class PropertyContext
         public int|float|null $maximum = null,
         public int|float|null $exclusiveMinimum = null,
         public int|float|null $exclusiveMaximum = null,
+        public ?Schema $schema = null,
     ) {
     }
 }

--- a/src/ClassSchemaGenerator/PropertyContextReader/AttributePropertyContextReader.php
+++ b/src/ClassSchemaGenerator/PropertyContextReader/AttributePropertyContextReader.php
@@ -104,6 +104,15 @@ readonly class AttributePropertyContextReader implements PropertyContextReaderIn
             return $attribute->schema;
         }
 
+        if (count($attributes) > 1) {
+            throw new DokkyException(sprintf(
+                'Property "%s" of class "%s" has multiple "%s" attributes, only one is allowed',
+                $property->getName(),
+                $property->getDeclaringClass()->getName(),
+                \Dokky\Attribute\Property::class,
+            ));
+        }
+
         return null;
     }
 }

--- a/src/ClassSchemaGenerator/PropertyContextReader/AttributePropertyContextReader.php
+++ b/src/ClassSchemaGenerator/PropertyContextReader/AttributePropertyContextReader.php
@@ -10,6 +10,7 @@ use Dokky\ClassSchemaGenerator\PropertyContext;
 use Dokky\ClassSchemaGenerator\PropertyContextReaderInterface;
 use Dokky\ClassSchemaGenerator\Util;
 use Dokky\DokkyException;
+use Dokky\OpenApi\Schema;
 
 readonly class AttributePropertyContextReader implements PropertyContextReaderInterface
 {
@@ -29,6 +30,7 @@ readonly class AttributePropertyContextReader implements PropertyContextReaderIn
             maximum: $constraints->maximum,
             exclusiveMinimum: $constraints->exclusiveMinimum,
             exclusiveMaximum: $constraints->exclusiveMaximum,
+            schema: $this->extractManuallyDefinedSchema($property),
         );
     }
 
@@ -90,5 +92,18 @@ readonly class AttributePropertyContextReader implements PropertyContextReaderIn
         }
 
         return new Constraints();
+    }
+
+    private function extractManuallyDefinedSchema(\ReflectionProperty $property): ?Schema
+    {
+        $attributes = $property->getAttributes(\Dokky\Attribute\Property::class);
+
+        if (1 === count($attributes)) {
+            $attribute = $attributes[0]->newInstance();
+
+            return $attribute->schema;
+        }
+
+        return null;
     }
 }

--- a/src/ClassSchemaGenerator/PropertyContextReader/ChainPropertyContextReader.php
+++ b/src/ClassSchemaGenerator/PropertyContextReader/ChainPropertyContextReader.php
@@ -30,6 +30,7 @@ readonly class ChainPropertyContextReader implements PropertyContextReaderInterf
         $maximum = null;
         $exclusiveMinimum = null;
         $exclusiveMaximum = null;
+        $schema = null;
 
         foreach ($this->readers as $reader) {
             $context = $reader->extract($property);
@@ -45,6 +46,7 @@ readonly class ChainPropertyContextReader implements PropertyContextReaderInterf
             $maximum ??= $context->maximum;
             $exclusiveMinimum ??= $context->exclusiveMinimum;
             $exclusiveMaximum ??= $context->exclusiveMaximum;
+            $schema ??= $context->schema;
         }
 
         return new PropertyContext(
@@ -59,6 +61,7 @@ readonly class ChainPropertyContextReader implements PropertyContextReaderInterf
             maximum: $maximum,
             exclusiveMinimum: $exclusiveMinimum,
             exclusiveMaximum: $exclusiveMaximum,
+            schema: $schema,
         );
     }
 }

--- a/src/OpenApi/Schema.php
+++ b/src/OpenApi/Schema.php
@@ -73,4 +73,15 @@ class Schema implements \JsonSerializable
         public Undefined|bool $uniqueItems = Undefined::VALUE,
     ) {
     }
+
+    public function manualOverwrite(self $schema): self
+    {
+        foreach (get_object_vars($schema) as $key => $value) {
+            if (!$value instanceof Undefined) {
+                $this->{$key} = $value;
+            }
+        }
+
+        return $this;
+    }
 }

--- a/tests/Datasets/ClassSchemas.php
+++ b/tests/Datasets/ClassSchemas.php
@@ -533,4 +533,20 @@ dataset('class-schemas', [
             )
         ),
     ],
+    [
+        'className' => Dokky\Tests\Datasets\Classes\DataWithSchemaOverwrite::class,
+        'groups' => null,
+        'expectedSchema' => new Schema(
+            type: Type::OBJECT,
+            properties: [
+                'property' => new Schema(
+                    type: Type::STRING,
+                    description: 'Some description',
+                    examples: ['test1', 'test2'],
+                    enum: ['test1', 'test2', 'test3'],
+                ),
+            ],
+            required: ['property'],
+        ),
+    ],
 ]);

--- a/tests/Datasets/Classes/DataWithSchemaOverwrite.php
+++ b/tests/Datasets/Classes/DataWithSchemaOverwrite.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dokky\Tests\Datasets\Classes;
+
+use Dokky\Attribute\Property;
+use Dokky\OpenApi\Schema;
+
+class DataWithSchemaOverwrite
+{
+    #[Property(
+        schema: new Schema(
+            description: 'Some description',
+            examples: ['test1', 'test2'],
+            enum: ['test1', 'test2', 'test3']
+        )
+    )]
+    public string $property;
+}

--- a/tests/Datasets/Classes/InvalidVariant5.php
+++ b/tests/Datasets/Classes/InvalidVariant5.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dokky\Tests\Datasets\Classes;
+
+use Dokky\Attribute\Property;
+use Dokky\OpenApi\Schema;
+
+class InvalidVariant5
+{
+    #[Property(schema: new Schema(enum: ['test1']))]
+    #[Property(schema: new Schema(enum: ['test2']))]
+    public string $property1;
+}

--- a/tests/Unit/InvalidAttributeUsageTest.php
+++ b/tests/Unit/InvalidAttributeUsageTest.php
@@ -49,3 +49,15 @@ test(
     Dokky\DokkyException::class,
     'Expected numeric value, got: string'
 );
+
+test(
+    'Property attribute should be used only once on a property',
+    function () {
+        new Dokky\ClassSchemaGenerator\ClassSchemaGenerator()
+            ->generate(Dokky\Tests\Datasets\Classes\InvalidVariant5::class);
+    }
+)
+->throws(
+    Dokky\DokkyException::class,
+    'Property "property1" of class "Dokky\Tests\Datasets\Classes\InvalidVariant5" has multiple "Dokky\Attribute\Property" attributes, only one is allowed'
+);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the README to display a new badge and include an example demonstrating how to define a property with a custom schema.

- **New Features**
  - Introduced a new attribute for annotating properties with schemas.
  - Enhanced schema generation by enabling manual overrides for property schemas.
  - Added new classes and dataset entries to support schema definitions in tests.

- **Tests**
  - Added new test cases to validate the usage of the `Property` attribute and ensure correct behavior with multiple attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->