### PR TITLE
feat: Adding configuration option to make nullable properties optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ class DataWithSchemaOverwrite
 }
 ```
 
+### Considering nullable properties as not-required
+
+Sometimes to be consistent with serializers, which can skip null values, you might want to consider nullable properties
+as not-required. In this case you can use a configuration option to switch the required property behavior.
+
+This can be done by passing a configuration object to the class schema generator like this:
+
+```php
+$configuration = new \Dokky\Configuration(
+    considerNullablePropertiesAsNotRequired: true,
+);
+new Dokky\ClassSchemaGenerator\ClassSchemaGenerator(configuration: $configuration)
+```
+
+
 ### Full documentation example
 ```php
 $componentsRegistry = new Dokky\ComponentsRegistry();

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dokky;
+
+readonly class Configuration
+{
+    /**
+     * @param bool $considerNullablePropertiesAsNotRequired when set to true, nullable properties will be considered as
+     *                                                      not required in the OpenAPI schema generation
+     */
+    public function __construct(
+        public bool $considerNullablePropertiesAsNotRequired = false,
+    ) {
+    }
+}

--- a/tests/Datasets/ClassSchemasWithDefaultNullables.php
+++ b/tests/Datasets/ClassSchemasWithDefaultNullables.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Dokky\OpenApi\Schema;
+use Dokky\OpenApi\Schema\Type;
+
+dataset('class-schemas-with-non-required-nullables', [
+    [
+        'className' => Dokky\Tests\Datasets\Classes\Basic::class,
+        'groups' => null,
+        'expectedSchema' => new Schema(
+            type: Type::OBJECT,
+            properties: [
+                'someStringProperty' => new Schema(type: Type::STRING),
+                'nullableIntProperty' => new Schema(
+                    anyOf: [
+                        new Schema(type: Type::INTEGER),
+                        new Schema(type: Type::NULL),
+                    ],
+                ),
+                'stringWithDefaultValue' => new Schema(
+                    default: 'some default value',
+                    anyOf: [
+                        new Schema(type: Type::STRING),
+                        new Schema(type: Type::NULL),
+                    ],
+                ),
+                'floatProperty' => new Schema(type: Type::NUMBER, format: 'float'),
+                'nullProperty' => new Schema(
+                    type: Type::NULL,
+                ),
+                'falseProperty' => new Schema(type: Type::BOOLEAN, enum: [false]),
+                'trueProperty' => new Schema(type: Type::BOOLEAN, enum: [true]),
+                'objectProperty' => new Schema(type: Type::OBJECT),
+            ],
+            required: [
+                'someStringProperty',
+                'floatProperty',
+                'falseProperty',
+                'trueProperty',
+                'objectProperty',
+            ],
+        ),
+    ],
+    [
+        'className' => Dokky\Tests\Datasets\Classes\MultiType::class,
+        'groups' => null,
+        'expectedSchema' => new Schema(
+            type: Type::OBJECT,
+            properties: [
+                'property' => new Schema(
+                    anyOf: [
+                        new Schema(type: Type::STRING),
+                        new Schema(type: Type::INTEGER),
+                        new Schema(type: Type::NULL),
+                    ],
+                ),
+            ],
+        ),
+    ],
+    [
+        'className' => Dokky\Tests\Datasets\Classes\Variant1::class,
+        'groups' => null,
+        'expectedSchema' => new Schema(
+            type: Type::OBJECT,
+            properties: [
+                'property' => new Schema(
+                    default: 5,
+                    anyOf: [
+                        new Schema(ref: '#/components/schemas/Basic'),
+                        new Schema(ref: '#/components/schemas/MultiType'),
+                        new Schema(type: Type::INTEGER),
+                        new Schema(type: Type::NULL),
+                    ],
+                ),
+            ],
+        ),
+    ],
+]);

--- a/tests/Unit/ClassSchemaGenerationTest.php
+++ b/tests/Unit/ClassSchemaGenerationTest.php
@@ -18,6 +18,29 @@ test(
 )->with('class-schemas');
 
 test(
+    'Can generate Json Schema from Class with default nullable configuration',
+
+    /**
+     * @param class-string  $className
+     * @param array<string> $groups
+     */
+    function (string $className, ?array $groups, Dokky\OpenApi\Schema $expectedSchema) {
+        $configuration = new Dokky\Configuration(
+            considerNullablePropertiesAsNotRequired: true,
+        );
+        $schema = cleanObject(
+            new Dokky\ClassSchemaGenerator\ClassSchemaGenerator(configuration: $configuration)
+                ->generate($className, $groups)
+        );
+        $expectedSchema = cleanObject($expectedSchema);
+
+        expect($schema)
+            ->toBeValidJsonSchema()
+            ->toEqual($expectedSchema);
+    }
+)->with('class-schemas-with-non-required-nullables');
+
+test(
     'Cannot get schema for empty class without properties',
     function () {
         $classSchemaGenerator = new Dokky\ClassSchemaGenerator\ClassSchemaGenerator();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to explain a new option for handling nullable properties in schema generation, enhancing user guidance on configuration.

- **New Features**
  - Introduced an optional configuration that enables nullable properties to be treated as not required during schema generation.

- **Tests**
  - Added tests to verify correct JSON schema generation when using the new nullable properties configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->