### PR TITLE
fix: Adding int as possible response array key, as PHP converts string keys to ints anyway

### DIFF
--- a/src/OpenApi/Operation.php
+++ b/src/OpenApi/Operation.php
@@ -16,7 +16,7 @@ class Operation implements \JsonSerializable
      * @param array<string, array<string, PathItem|Reference>|Reference>|Undefined $callbacks
      * @param array<string, string[]>                                              $security
      * @param array<Server>                                                        $servers
-     * @param Undefined|array<string, Response|Reference>                          $responses
+     * @param Undefined|array<string|int, Response|Reference>                      $responses
      */
     public function __construct(
         public Undefined|array $tags = Undefined::VALUE,

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -42,6 +42,24 @@ expect()->extend('toBeValidJsonSchema', function () {
     return $this;
 });
 
+expect()->extend('toBeValidOpenApiSchema', function () {
+    $validator = new JsonSchema\Validator();
+    $validator->validate(
+        $this->value,
+        (object) ['$ref' => 'file://'.__DIR__.'/schemas/openapi/schema.json']
+    );
+
+    $errorMessages = [];
+
+    foreach ($validator->getErrors() as $error) {
+        $errorMessages[] = sprintf("[%s] %s\n", $error['property'], $error['message']);
+    }
+
+    expect($validator->isValid())->toBeTrue(implode(PHP_EOL, $errorMessages));
+
+    return $this;
+});
+
 /*
 |--------------------------------------------------------------------------
 | Functions

--- a/tests/Unit/FullSpecTest.php
+++ b/tests/Unit/FullSpecTest.php
@@ -101,10 +101,10 @@ test(
                                     ),
                                 ],
                             ),
-                            '401' => new Dokky\OpenApi\Reference(
+                            401 => new Dokky\OpenApi\Reference(
                                 ref: '#/components/responses/Unauthorized',
                             ),
-                            '404' => new Dokky\OpenApi\Response(
+                            404 => new Dokky\OpenApi\Response(
                                 description: 'User not found',
                             ),
                         ],
@@ -169,6 +169,8 @@ test(
         );
 
         expect($openApi)
-            ->not->toBeEmpty();
+            ->not->toBeEmpty()
+            ->and(cleanObject($openApi))
+            ->toBeValidOpenApiSchema();
     }
 );

--- a/tests/schemas/openapi/schema.json
+++ b/tests/schemas/openapi/schema.json
@@ -1,0 +1,92 @@
+{
+    "$id": "https://spec.openapis.org/oas/3.1/meta/2024-11-10",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "OAS Base Vocabulary",
+    "description": "A JSON Schema Vocabulary used in the OpenAPI Schema Dialect",
+    "$dynamicAnchor": "meta",
+    "$vocabulary": {
+        "https://spec.openapis.org/oas/3.1/vocab/base": true
+    },
+    "type": [
+        "object",
+        "boolean"
+    ],
+    "properties": {
+        "discriminator": {
+            "$ref": "#/$defs/discriminator"
+        },
+        "example": true,
+        "externalDocs": {
+            "$ref": "#/$defs/external-docs"
+        },
+        "xml": {
+            "$ref": "#/$defs/xml"
+        }
+    },
+    "$defs": {
+        "discriminator": {
+            "$ref": "#/$defs/extensible",
+            "properties": {
+                "mapping": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                "propertyName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "propertyName"
+            ],
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "extensible": {
+            "patternProperties": {
+                "^x-": true
+            }
+        },
+        "external-docs": {
+            "$ref": "#/$defs/extensible",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "url": {
+                    "format": "uri-reference",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "url"
+            ],
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "xml": {
+            "$ref": "#/$defs/extensible",
+            "properties": {
+                "attribute": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "format": "uri",
+                    "type": "string"
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "wrapped": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "unevaluatedProperties": false
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded API response support to handle both text and numeric keys.
	- Introduced a new JSON schema to standardize the API specification vocabulary.

- **Tests**
	- Added enhanced validation checks to ensure API definitions conform to the latest OpenAPI standards.
	- Improved test coverage for verifying response codes and overall API structure integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->