### PR TITLE
feat: Adding support for nested groups

### DIFF
--- a/src/ClassSchemaGenerator/ClassSchemaGenerator.php
+++ b/src/ClassSchemaGenerator/ClassSchemaGenerator.php
@@ -95,7 +95,12 @@ readonly class ClassSchemaGenerator implements ClassSchemaGeneratorInterface
             }
 
             $finalName = $propertyContext->name ?? $propertyName;
-            $propertySchema = $this->generatePropertySchema($className, $propertyName, $reflectionProperty);
+            $propertySchema = $this->generatePropertySchema(
+                className: $className,
+                propertyName: $propertyName,
+                reflectionProperty: $reflectionProperty,
+                groups: $groups,
+            );
             $properties[$finalName] = $propertySchema;
 
             // Constraints
@@ -149,10 +154,14 @@ readonly class ClassSchemaGenerator implements ClassSchemaGeneratorInterface
         return $schema;
     }
 
+    /**
+     * @param array<string>|null $groups
+     */
     private function generatePropertySchema(
         string $className,
         string $propertyName,
         \ReflectionProperty $reflectionProperty,
+        ?array $groups = null,
     ): Schema {
         $typeInfoType = $this->propertyInfoExtractor->getType($className, $propertyName);
 
@@ -163,7 +172,7 @@ readonly class ClassSchemaGenerator implements ClassSchemaGeneratorInterface
         $shortDescription = $this->propertyInfoExtractor->getShortDescription($className, $propertyName);
         $longDescription = $this->propertyInfoExtractor->getLongDescription($className, $propertyName);
         $description = trim(($shortDescription ?? '').($longDescription ? "\n".$longDescription : ''));
-        $schema = $this->typeMapper->typeToSchema($typeInfoType);
+        $schema = $this->typeMapper->typeToSchema($typeInfoType, $groups);
 
         $schema->default = $this->determineDefaultValue($reflectionProperty);
 

--- a/tests/Datasets/Classes/Groups/NestedObject.php
+++ b/tests/Datasets/Classes/Groups/NestedObject.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dokky\Tests\Datasets\Classes\Groups;
+
+use Dokky\Attribute\Groups;
+
+readonly class NestedObject
+{
+    public string $noGroup;
+
+    #[Groups(['group1'])]
+    public string $group1;
+}

--- a/tests/Datasets/Classes/Groups/RootObject.php
+++ b/tests/Datasets/Classes/Groups/RootObject.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dokky\Tests\Datasets\Classes\Groups;
+
+use Dokky\Attribute\Groups;
+
+readonly class RootObject
+{
+    public string $directProperty;
+
+    public NestedObject $nestedObject;
+
+    /**
+     * @var array<NestedObject>
+     */
+    public array $arrayOfNestedObjects;
+
+    #[Groups(['group1'])]
+    public string $directProperty2;
+
+    #[Groups(['group1'])]
+    public NestedObject $nestedObject2;
+
+    /**
+     * @var array<NestedObject>
+     */
+    #[Groups(['group1'])]
+    public array $arrayOfNestedObjects2;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added group-aware schema generation, enabling schemas to be filtered by specified groups.
  - Group context is now propagated through nested objects, collections, nullable, and union types.
  - Schema references resolve with group context for consistent component reuse.

- Tests
  - Introduced tests covering nested group scenarios, verifying that only grouped properties are included and required as expected.
  - Added dataset classes to validate grouping behavior across direct properties, nested objects, and arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->